### PR TITLE
Describe the special powers some unrandarts have in art-data.txt

### DIFF
--- a/crawl-ref/source/cloud.cc
+++ b/crawl-ref/source/cloud.cc
@@ -1061,9 +1061,8 @@ static int _actor_cloud_resist(const actor *act, const cloud_struct &cloud)
 
 static bool _mephitic_cloud_roll(const monster* mons)
 {
-    const int meph_hd_cap = 21;
-    return mons->get_hit_dice() >= meph_hd_cap? one_chance_in(50)
-           : !x_chance_in_y(mons->get_hit_dice(), meph_hd_cap);
+    return mons->get_hit_dice() >= MEPH_HD_CAP ? one_chance_in(50)
+           : !x_chance_in_y(mons->get_hit_dice(), MEPH_HD_CAP);
 }
 
 // Applies cloud messages and side-effects and returns true if the

--- a/crawl-ref/source/cloud.h
+++ b/crawl-ref/source/cloud.h
@@ -52,6 +52,8 @@ struct cloud_tile_info
     cloud_tile_variation variation;  ///< How (and if) the tile should vary.
 };
 
+#define MEPH_HD_CAP 21
+
 cloud_struct* cloud_at(coord_def pos);
 
 cloud_type cloud_type_at(const coord_def &pos);

--- a/crawl-ref/source/dat/des/sprint/arena_sprint.des
+++ b/crawl-ref/source/dat/des/sprint/arena_sprint.des
@@ -367,7 +367,7 @@ function arena_sprint_get_monster_set(round, boss)
                 "shapeshifter",
                 -- Gimmicks
                 "neqoxec",
-                "moth of wrath / w:20 two-headed ogre", "ball lightning",
+                "moth of wrath / w:20 two-headed ogre",
                 "boulder beetle", "orb spider", "redback / sea snake w:3",
                 "shining eye"
             }
@@ -433,7 +433,7 @@ function arena_sprint_get_monster_set(round, boss)
                 "vampire / vampire knight / vampire mage / w:1 jory",
                 -- Gimmicks
                 "neqoxec", "smoke demon", "catoblepas",
-                "moth of wrath / w:20 stone giant", "ball lightning",
+                "moth of wrath / w:20 stone giant",
                 "boulder beetle", "orb spider", "shining eye", "tormentor",
                 "skeletal warrior / w:5 skeletal warrior ; dart ego:atropa"
             }
@@ -473,7 +473,7 @@ function arena_sprint_get_monster_set(round, boss)
                     fire giant / sun demon / fire vortex",
                 "place:Coc:$ w:20 / ice fiend / blizzard demon / ice devil",
                 "spriggan air mage / w:5 titan / w:5 electric golem / wind drake /\
-                    air elemental / ball lightning / storm dragon",
+                    air elemental / storm dragon",
                 "tzitzimitl / reaper / shadow dragon / death drake /\
                     deep elf death mage / lich w:15 / ancient lich w:5 /\
                     death knight w:5 / place:Tar:$ w:40",
@@ -546,8 +546,7 @@ function arena_sprint_get_monster_set(round, boss)
                     fire giant / sun demon",
                 "place:Coc:$ w:20 / ice fiend / blizzard demon / ice devil /\
                     white draconian",
-                "spriggan air mage / titan / electric golem / ball lightning /\
-                    storm dragon",
+                "spriggan air mage / titan / electric golem / storm dragon",
                 "tzitzimitl / reaper / shadow dragon / death drake /\
                     deep elf death mage / ancient lich /\
                     death knight w:5 / place:Tar:$ w:40",

--- a/crawl-ref/source/dat/descript/items.txt
+++ b/crawl-ref/source/dat/descript/items.txt
@@ -554,8 +554,7 @@ A short club with a metal head.
 %%%%
 manual
 
-A valuable book which allows one to practise a certain skill more efficiently
-when carried.
+A valuable book which allows one to learn a certain skill faster.
 %%%%
 morningstar
 

--- a/crawl-ref/source/describe.cc
+++ b/crawl-ref/source/describe.cc
@@ -4658,11 +4658,11 @@ void get_monster_db_desc(const monster_info& mi, describe_info &inf,
         has_stat_desc = true;
     }
 
-    bool stair_use = false;
+    bool did_stair_use = false;
     if (!mons_class_can_use_stairs(mi.type))
     {
         inf.body << It << " " << is << " incapable of using stairs.\n";
-        stair_use = true;
+        did_stair_use = true;
     }
 
     if (mi.is(MB_SUMMONED) || mi.is(MB_PERM_SUMMON))
@@ -4684,11 +4684,11 @@ void get_monster_db_desc(const monster_info& mi, describe_info &inf,
             inf.body << "Killing " << it_o << " yields ";
         inf.body << "no experience or items";
 
-        if (!stair_use)
-            inf.body << "; " << it << " " << is << " incapable of using stairs";
+        if (!did_stair_use && !mi.is(MB_PERM_SUMMON))
+            inf.body << " and " << it << " " << is << " incapable of using stairs";
 
         if (mi.is(MB_PERM_SUMMON))
-            inf.body << ", and " << it << " cannot be abjured";
+            inf.body << " and " << it << " cannot be abjured";
 
         inf.body << ".\n";
     }

--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -282,118 +282,12 @@ void zap_wand(int slot, dist *_target)
     you.turn_is_over = true;
 }
 
-// return a slot that has manual for given skill, or -1 if none exists
-// in case of multiple manuals the one with the fewest charges is returned
-int manual_slot_for_skill(skill_type skill)
-{
-    int slot = -1;
-    int charges = -1;
-
-    FixedVector<item_def,ENDOFPACK>::const_pointer iter = you.inv.begin();
-    for (;iter!=you.inv.end(); ++iter)
-    {
-        if (iter->base_type != OBJ_BOOKS || iter->sub_type != BOOK_MANUAL
-            || is_useless_item(*iter))
-        {
-            continue;
-        }
-
-        if (iter->skill != skill || iter->skill_points == 0)
-            continue;
-
-        if (slot != -1 && iter->skill_points > charges)
-            continue;
-
-        slot = iter - you.inv.begin();
-        charges = iter->skill_points;
-    }
-
-    return slot;
-}
-
-int get_all_manual_charges_for_skill(skill_type skill)
-{
-    // Gnolls can't focus well enough to use manuals
-    if (you.species == SP_GNOLL)
-        return 0;
-
-    int charges = 0;
-
-    FixedVector<item_def,ENDOFPACK>::const_pointer iter = you.inv.begin();
-    for (;iter!=you.inv.end(); ++iter)
-    {
-        if (iter->base_type != OBJ_BOOKS || iter->sub_type != BOOK_MANUAL)
-            continue;
-
-        if (iter->skill != skill || iter->skill_points == 0)
-            continue;
-
-        charges += iter->skill_points;
-    }
-
-    return charges;
-}
-
-bool skill_has_manual(skill_type skill)
-{
-    return manual_slot_for_skill(skill) != -1;
-}
-
-void finish_manual(int slot)
-{
-    item_def& manual(you.inv[slot]);
-    const skill_type skill = static_cast<skill_type>(manual.plus);
-
-    mprf("You have finished your manual of %s and toss it away.",
-         skill_name(skill));
-    dec_inv_item_quantity(slot, 1);
-}
-
-void get_all_manual_charges(vector<int> &charges)
-{
-    charges.clear();
-
-    FixedVector<item_def,ENDOFPACK>::const_pointer iter = you.inv.begin();
-    for (;iter!=you.inv.end(); ++iter)
-    {
-        if (iter->base_type != OBJ_BOOKS || iter->sub_type != BOOK_MANUAL)
-            continue;
-
-        charges.push_back(iter->skill_points);
-    }
-}
-
-void set_all_manual_charges(const vector<int> &charges)
-{
-    auto charge_iter = charges.begin();
-    for (item_def &item : you.inv)
-    {
-        if (item.base_type != OBJ_BOOKS || item.sub_type != BOOK_MANUAL)
-            continue;
-
-        ASSERT(charge_iter != charges.end());
-        item.skill_points = *charge_iter;
-        charge_iter++;
-    }
-    ASSERT(charge_iter == charges.end());
-}
-
 string manual_skill_names(bool short_text)
 {
     skill_set skills;
-
-    FixedVector<item_def,ENDOFPACK>::const_pointer iter = you.inv.begin();
-    for (;iter!=you.inv.end(); ++iter)
-    {
-        if (iter->base_type != OBJ_BOOKS
-            || iter->sub_type != BOOK_MANUAL
-            || is_useless_item(*iter))
-        {
-            continue;
-        }
-
-        skills.insert(static_cast<skill_type>(iter->plus));
-    }
+    for (skill_type sk = SK_FIRST_SKILL; sk < NUM_SKILLS; sk++)
+        if (you.skill_manual_points[sk])
+            skills.insert(sk);
 
     if (short_text && skills.size() > 1)
     {

--- a/crawl-ref/source/evoke.h
+++ b/crawl-ref/source/evoke.h
@@ -9,12 +9,6 @@
 
 using std::vector;
 
-int manual_slot_for_skill(skill_type skill);
-int get_all_manual_charges_for_skill(skill_type skill);
-bool skill_has_manual(skill_type skill);
-void finish_manual(int slot);
-void get_all_manual_charges(vector<int> &charges);
-void set_all_manual_charges(const vector<int> &charges);
 string manual_skill_names(bool short_text=false);
 
 void wind_blast(actor* agent, int pow, coord_def target, bool card = false);

--- a/crawl-ref/source/fineff.cc
+++ b/crawl-ref/source/fineff.cc
@@ -256,13 +256,17 @@ void blink_fineff::fire()
     actor *defend = defender();
     if (!defend || !defend->alive() || defend->no_tele(true, false))
         return;
+    
+    // if we're doing 'blink with', only blink if we have a partner
+    actor *pal = attacker();
+    if (pal && (!pal->alive() || pal->no_tele(true, false)))
+        return;
 
     defend->blink();
     if (!defend->alive())
         return;
 
     // Is something else also getting blinked?
-    actor *pal = attacker();
     if (!pal || !pal->alive() || pal->no_tele(true, false))
         return;
 

--- a/crawl-ref/source/hints.cc
+++ b/crawl-ref/source/hints.cc
@@ -3270,9 +3270,9 @@ string hints_describe_item(const item_def &item)
             if (item.sub_type == BOOK_MANUAL)
             {
                 ostr << "A manual can greatly help you in training a skill. "
-                        "As long as you are carrying it, the skill in "
-                        "question will be trained more efficiently and will "
-                        "level up faster.";
+                        "After you pick one up, the skill in question will be "
+                        "trained more efficiently and will level up faster "
+                        "until you exhaust the manual's contents.";
                 cmd.push_back(CMD_READ);
             }
             else // It's a spellbook!

--- a/crawl-ref/source/initfile.cc
+++ b/crawl-ref/source/initfile.cc
@@ -320,7 +320,6 @@ const vector<GameOption*> game_options::build_options_list()
         new BoolGameOption(SIMPLE_NAME(restart_after_save), true),
         new BoolGameOption(SIMPLE_NAME(newgame_after_quit), false),
         new StringGameOption(SIMPLE_NAME(map_file_name), ""),
-        new StringGameOption(SIMPLE_NAME(save_dir), _get_save_path("saves/")),
         new StringGameOption(SIMPLE_NAME(morgue_dir),
                              _get_save_path("morgue/")),
 #endif
@@ -1029,8 +1028,8 @@ void game_options::reset_options()
 
     macro_dir = SysEnv.macro_dir;
 
-#ifdef DGAMELAUNCH
     save_dir = _get_save_path("saves/");
+#ifdef DGAMELAUNCH
     morgue_dir = _get_save_path("morgue/");
 #else
     if (macro_dir.empty())
@@ -2971,6 +2970,15 @@ void game_options::read_option_line(const string &str, bool runscript)
         // We shouldn't bother to allocate this a second time
         // if the user puts two crawl_dir lines in the init file.
         SysEnv.crawl_dir = field;
+    }
+#endif
+#ifndef SAVE_DIR_PATH
+    else if (key == "save_dir")
+    {
+        save_dir = field;
+#ifndef SHARED_DIR_PATH
+        shared_dir = save_dir;
+#endif
     }
     else if (key == "macro_dir")
         macro_dir = field;

--- a/crawl-ref/source/item-name.cc
+++ b/crawl-ref/source/item-name.cc
@@ -3149,9 +3149,7 @@ bool is_useless_item(const item_def &item, bool temp, bool ident)
         // If we're here, it's a manual.
         if (you.skills[item.plus] >= 27)
             return true;
-        if (is_useless_skill((skill_type)item.plus))
-            return true;
-        return you.species == SP_GNOLL;
+        return is_useless_skill((skill_type)item.plus);
 
     default:
         return false;

--- a/crawl-ref/source/items.cc
+++ b/crawl-ref/source/items.cc
@@ -1797,10 +1797,21 @@ bool move_item_to_inv(int obj, int quant_got, bool quiet)
 
 static void _get_book(const item_def& it)
 {
-    mprf("You pick up %s and begin reading...", it.name(DESC_A).c_str());
+    if (it.sub_type != BOOK_MANUAL)
+    {
+        mprf("You pick up %s and begin reading...", it.name(DESC_A).c_str());
 
-    if (!library_add_spells(spells_in_book(it)))
-        mpr("Unfortunately, you learned nothing new.");
+        if (!library_add_spells(spells_in_book(it)))
+            mpr("Unfortunately, you learned nothing new.");
+        return;
+    }
+
+    const skill_type sk = static_cast<skill_type>(it.plus);
+    if (you.skill_manual_points[sk])
+        mprf("You pick up another %s and continue studying.", it.name(DESC_PLAIN).c_str());
+    else
+        mprf("You pick up %s and begin studying.", it.name(DESC_A).c_str());
+    you.skill_manual_points[sk] += it.skill_points;
 }
 
 // Adds all books in the player's inventory to library.
@@ -1810,7 +1821,7 @@ void add_held_books_to_library()
 {
     for (item_def& it : you.inv)
     {
-        if (it.base_type == OBJ_BOOKS && it.sub_type != BOOK_MANUAL)
+        if (it.base_type == OBJ_BOOKS)
         {
             _get_book(it);
             destroy_item(it);
@@ -2108,7 +2119,7 @@ static bool _merge_items_into_inv(item_def &it, int quant_got,
         get_gold(it, quant_got, quiet);
         return true;
     }
-    if (it.base_type == OBJ_BOOKS && it.sub_type != BOOK_MANUAL)
+    if (it.base_type == OBJ_BOOKS)
     {
         _get_book(it);
         return true;

--- a/crawl-ref/source/mon-gear.cc
+++ b/crawl-ref/source/mon-gear.cc
@@ -2235,8 +2235,8 @@ void view_monster_equipment(monster* mon)
             continue;
 
         item_def &item = env.item[mon->inv[i]];
-        item.flags |= ISFLAG_SEEN;
         set_ident_flags(item, ISFLAG_IDENT_MASK);
+        item.flags |= ISFLAG_SEEN;
         if (item.base_type == OBJ_WANDS)
             set_ident_type(item, true);
     }

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5132,6 +5132,7 @@ void player::init_skills()
     skill_points.init(0);
     ct_skill_points.init(0);
     skill_order.init(MAX_SKILL_ORDER);
+    skill_manual_points.init(0);
     training_targets.init(0);
     exercises.clear();
     exercises_all.clear();

--- a/crawl-ref/source/player.h
+++ b/crawl-ref/source/player.h
@@ -220,6 +220,10 @@ public:
     FixedVector<unsigned int, NUM_SKILLS> ct_skill_points;
     FixedVector<uint8_t, NUM_SKILLS>  skill_order;
 
+    /// manuals
+    FixedVector<unsigned int, NUM_SKILLS>  skill_manual_points;
+
+
     bool auto_training;
     list<skill_type> exercises;     ///< recent practise events
     list<skill_type> exercises_all; ///< also include events for disabled skills

--- a/crawl-ref/source/skill-menu.cc
+++ b/crawl-ref/source/skill-menu.cc
@@ -309,7 +309,7 @@ COLOURS SkillMenuEntry::get_colour() const
         return YELLOW;
     else if (!you.training[m_sk])
         return DARKGREY;
-    else if (skill_has_manual(m_sk))
+    else if (you.skill_manual_points[m_sk])
         return LIGHTBLUE;
     else if (you.train[m_sk] == TRAINING_FOCUSED)
         return WHITE;
@@ -338,7 +338,7 @@ void SkillMenuEntry::set_aptitude()
 {
     string text = "<white>";
 
-    const bool manual = skill_has_manual(m_sk);
+    const bool manual = you.skill_manual_points[m_sk] > 0;
     const int apt = species_apt(m_sk, you.species);
 
     if (apt != 0)
@@ -529,7 +529,7 @@ void SkillMenuEntry::set_cost()
 
     if (you.skills[m_sk] == MAX_SKILL_LEVEL)
         return;
-    if (skill_has_manual(m_sk))
+    if (you.skill_manual_points[m_sk])
         m_progress->set_fg_colour(LIGHTRED);
     else
         m_progress->set_fg_colour(CYAN);

--- a/crawl-ref/source/skills.h
+++ b/crawl-ref/source/skills.h
@@ -26,11 +26,11 @@ struct skill_state
     FixedVector<unsigned int, NUM_SKILLS> training_targets;
     FixedVector<unsigned int, NUM_SKILLS> ct_skill_points;
     FixedVector<uint8_t, NUM_SKILLS>      skill_order;
+    FixedVector<unsigned int, NUM_SKILLS> skill_manual_points;
     int skill_cost_level;
     unsigned int total_experience;
     bool auto_training;
     int exp_available;
-    vector<int> manual_charges;
 
     void save();
     bool state_saved() const;

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1713,11 +1713,11 @@ spret your_spells(spell_type spell, int powc, bool allow_fail,
                                 || spell == SPELL_APPORTATION;
 
         // Add success chance to targeted spells checking monster WL
-        const bool mr_check = testbits(flags, spflag::WL_check)
+        const bool wl_check = testbits(flags, spflag::WL_check)
                               && !testbits(flags, spflag::helpful);
         desc_filter additional_desc = nullptr;
         const zap_type zap = spell_to_zap(spell);
-        if (mr_check)
+        if (wl_check)
         {
             const int eff_pow = zap != NUM_ZAPS ? zap_ench_power(zap, powc,
                                                                  false)

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1537,7 +1537,9 @@ static vector<string> _desc_dazzle_chance(const monster_info& mi, int pow)
     if (!mons_can_be_dazzled(mi.type))
         return vector<string>{"not susceptible"};
 
-    const int dazzle_pct = max(100 * ( 95 - mi.hd * 4 ) / ( 150 - pow ), 0);
+    const int numerator = dazzle_chance_numerator(mi.hd);
+    const int denom = dazzle_chance_denom(pow);
+    const int dazzle_pct = max(100 * numerator / denom, 0);
 
     return vector<string>{make_stringf("chance to dazzle: %d%%", dazzle_pct)};
 }

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -16,6 +16,7 @@
 #include "art-enum.h"
 #include "beam.h"
 #include "chardump.h"
+#include "cloud.h"
 #include "colour.h"
 #include "coordit.h"
 #include "database.h"
@@ -1544,6 +1545,17 @@ static vector<string> _desc_dazzle_chance(const monster_info& mi, int pow)
     return vector<string>{make_stringf("chance to dazzle: %d%%", dazzle_pct)};
 }
 
+static vector<string> _desc_meph_chance(const monster_info& mi)
+{
+    if (!mi.mresists & MR_RES_POISON || mons_is_unbreathing(mi.type))
+        return vector<string>{"not susceptible"};
+
+    int pct_chance = 2;
+    if (mi.hd < MEPH_HD_CAP)
+        pct_chance = 100 - (100 * mi.hd / MEPH_HD_CAP);
+    return vector<string>{make_stringf("chance to affect: %d%%", pct_chance)};
+}
+
 static string _mon_threat_string(const CrawlStoreValue &mon_store)
 {
     monster dummy;
@@ -1657,6 +1669,8 @@ static desc_filter _targeter_addl_desc(spell_type spell, int powc, spell_flags f
                         hitfunc, powc);
         case SPELL_DAZZLING_FLASH:
             return bind(_desc_dazzle_chance, placeholders::_1, powc);
+        case SPELL_MEPHITIC_CLOUD:
+            return bind(_desc_meph_chance, placeholders::_1);
         default:
             break;
     }

--- a/crawl-ref/source/spl-damage.cc
+++ b/crawl-ref/source/spl-damage.cc
@@ -2645,12 +2645,23 @@ void forest_damage(const actor *mon)
     }
 }
 
+int dazzle_chance_numerator(int hd)
+{
+    return 95 - hd * 4;
+}
+
+int dazzle_chance_denom(int pow)
+{
+    return 150 - pow;
+}
+
 bool dazzle_monster(monster * mons, int pow)
 {
     if (!mons || !mons_can_be_dazzled(mons->type))
         return false;
 
-    if (x_chance_in_y(95 - mons->get_hit_dice() * 4 , 150 - pow))
+    const int numerator = dazzle_chance_numerator(mons->get_hit_dice());
+    if (x_chance_in_y(numerator, dazzle_chance_denom(pow)))
     {
         mons->add_ench(mon_enchant(ENCH_BLIND, 1, &you,
                        random_range(4, 8) * BASELINE_DELAY));

--- a/crawl-ref/source/spl-damage.h
+++ b/crawl-ref/source/spl-damage.h
@@ -62,6 +62,8 @@ void forest_message(const coord_def pos, const string &msg,
                     msg_channel_type ch = MSGCH_PLAIN);
 void forest_damage(const actor *mon);
 
+int dazzle_chance_numerator(int hd);
+int dazzle_chance_denom(int pow);
 bool dazzle_monster(monster *mon, int pow);
 spret cast_dazzling_flash(int pow, bool fail, bool tracer = false);
 

--- a/crawl-ref/source/tag-version.h
+++ b/crawl-ref/source/tag-version.h
@@ -254,6 +254,7 @@ enum tag_minor_version
     TAG_MINOR_APPENDAGE,           // Change beastly appendage
     TAG_MINOR_REALLY_UNSTACK_EVOKERS, // Unstack all evokers
     TAG_MINOR_SETPOLY,             // Despoiler polymorph wands
+    TAG_MINOR_GOLDIFY_MANUALS,     // Move manuals out of the inventory
 #endif
     NUM_TAG_MINORS,
     TAG_MINOR_VERSION = NUM_TAG_MINORS - 1

--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -1487,6 +1487,7 @@ static void _tag_construct_you(writer &th)
         marshallInt(th, you.ct_skill_points[j]);
         marshallByte(th, you.skill_order[j]);   // skills ordering
         marshallInt(th, you.training_targets[j]);
+        marshallInt(th, you.skill_manual_points[j]);
     }
 
     marshallBoolean(th, you.auto_training);
@@ -2849,6 +2850,15 @@ static void _tag_read_you(reader &th)
         }
         else
             you.training_targets[j] = 0;
+
+        if (th.getMinorVersion() >= TAG_MINOR_GOLDIFY_MANUALS)
+        {
+#endif
+            you.skill_manual_points[j] = unmarshallInt(th);
+#if TAG_MAJOR_VERSION == 34
+        }
+        else
+            you.skill_manual_points[j] = 0;
 #endif
     }
 
@@ -4147,7 +4157,8 @@ static void _tag_read_you_items(reader &th)
         reset_training();
 
     // Move any books from inventory into the player's library.
-    if (th.getMinorVersion() < TAG_MINOR_GOLDIFY_BOOKS)
+    // (Likewise for manuals.)
+    if (th.getMinorVersion() < TAG_MINOR_GOLDIFY_MANUALS)
         add_held_books_to_library();
 #endif
 }

--- a/crawl-ref/source/travel.cc
+++ b/crawl-ref/source/travel.cc
@@ -1841,9 +1841,9 @@ void find_travel_pos(const coord_def& youpos,
     //
     // .tx      Moving onto t puts us adjacent to an unseen grid.
     // ?#@      --> Pick x instead.
-
     // Only applies to diagonal moves.
-    if (rmode == RMODE_TRAVEL && *move_x != 0 && *move_y != 0)
+    if (rmode == RMODE_TRAVEL && !dest.origin() && dest.x != youpos.x
+        && dest.y != youpos.y)
     {
         coord_def unseen = coord_def();
         for (adjacent_iterator ai(dest); ai; ++ai)

--- a/crawl-ref/source/viewmap.cc
+++ b/crawl-ref/source/viewmap.cc
@@ -573,10 +573,58 @@ static coord_def _recentre_map_target(const level_id level,
 }
 
 #ifndef USE_TILE_LOCAL
-static map_view_state _get_view_state(const map_control_state& state)
+static map_view_state _get_view_state(coord_def cur_ul, const map_control_state& state)
 {
-    map_view_state view;
+    // TODO: why should local tiles use different logic?
+    // also, these might make more sense as member functions of UIMapView.
 
+    // recalculate cursor position, and scroll if necessary
+    map_view_state view;
+    const int num_lines = _get_number_of_lines_levelmap();
+
+    view.start.x = cur_ul.x;
+    view.start.y = cur_ul.y;
+
+    // Scroll when needed to keep MARGIN rows/cols to the left or right of the
+    // cursor -- as long as there is map to scroll to.
+    const int MARGIN = 3;
+
+    // careful with off-by-one errors in these calcs
+    view.cursor = state.lpos.pos - view.start + coord_def(1,1);
+    const auto bounds = known_map_bounds();
+    const coord_def map_min = state.lpos.pos - bounds.first;
+    const coord_def map_max = bounds.second - state.lpos.pos;
+    const coord_def ul_margin(max(0, min(MARGIN, map_min.x)),
+                              max(0, min(MARGIN, map_min.y)));
+    const coord_def lr_margin(max(0, min(MARGIN, map_max.x)),
+                              max(0, min(MARGIN, map_max.y)));
+
+    // First check upper-left margins
+    // In principle x doesn't need to scroll; a level can't be larger than 80
+    // columns. But let's make the logic general.
+    coord_def shift = coord_def(min(0, view.cursor.x - ul_margin.x - 1),
+                                min(0, view.cursor.y - ul_margin.y - 1));
+
+    // If we didn't enforce any margins on the upper-left, check lower-right
+    if (shift.x >= 0)
+        shift.x = max(0, view.cursor.x - get_number_of_cols() + lr_margin.x);
+    if (shift.y >= 0)
+        shift.y = max(0, view.cursor.y - num_lines + lr_margin.y);
+
+    view.start += shift;
+
+    // now calculate the final cursor position relative to any view shifting
+    // that happened to enforce margins
+    view.cursor = state.lpos.pos - view.start + coord_def(1,1);
+    return view;
+}
+
+static map_view_state _init_view_state(const map_control_state& state)
+{
+    // initial placement calculations for the map viewport window.
+    // This code is a bit inscrutable but it seems to do some heuristics to
+    // try to make partially explored levels look reasonable in console map
+    // view, mostly to do with placement in the x direction.
     const int num_lines = _get_number_of_lines_levelmap();
     const int half_screen = (num_lines - 1) / 2;
 
@@ -588,8 +636,7 @@ static map_view_state _get_view_state(const map_control_state& state)
 
     const auto map_lines = max_y - min_y + 1;
 
-    view.start.x = (min_x + max_x + 1) / 2 - 40;  // no x scrolling.
-    view.start.y = 0;                             // y does scroll.
+    coord_def ul((min_x + max_x + 1) / 2 - 40, 0);
 
     auto screen_y = state.lpos.pos.y;
 
@@ -608,12 +655,11 @@ static map_view_state _get_view_state(const map_control_state& state)
     else if (screen_y + half_screen > max_y)
         screen_y = max_y - half_screen;
 
-    view.cursor.x = state.lpos.pos.x - view.start.x + 1;
-    view.cursor.y = state.lpos.pos.y - screen_y + half_screen + 1;
+    ul.y = screen_y - half_screen;
 
-    view.start.y = screen_y - half_screen;
-
-    return view;
+    // Finally, adjust the upper left corner for the view state so that it is
+    // appropriately scrolled relative to the cursor.
+    return _get_view_state(ul, state);
 }
 #endif
 
@@ -653,11 +699,13 @@ public:
 #endif
 
 #ifndef USE_TILE_LOCAL
-        const auto view = _get_view_state(m_state);
+        const auto view = _get_view_state(view_ul, m_state);
+        view_ul = view.start;
         _draw_title(m_state.lpos.pos, *m_state.feats, m_region.width);
         const ui::Region map_region = {0, 1, m_region.width, m_region.height - 1};
-        _draw_level_map(view.start.x, view.start.y, m_state.travel_mode,
+        _draw_level_map(view_ul.x, view_ul.y, m_state.travel_mode,
                         m_state.on_level, map_region);
+        // the `+ 1` here is for the map overview line
         ui::show_cursor_at(view.cursor.x, view.cursor.y + 1);
 #endif
     }
@@ -756,6 +804,10 @@ public:
                 _recentre_map_target(m_state.lpos.id, m_state.original);
             m_state.lpos.id = level_id::current();
         }
+#ifndef USE_TILE_LOCAL
+        auto s = _init_view_state(m_state);
+        view_ul = s.start;
+#endif
 
         _expose();
     }
@@ -782,6 +834,10 @@ private:
     vector<coord_def> m_features;
     // List of all interesting features for display in the (console) title.
     feature_list m_feats;
+
+#ifndef USE_TILE_LOCAL
+    coord_def view_ul;
+#endif
 
 #ifdef USE_TILE_LOCAL
     bool first_run = true;


### PR DESCRIPTION
1, Describe the special powers the staff of Olgreb, the storm bow and Maxwell's Thermic Engine have in art-data.txt rather than describe.cc. 
2. Expand the special power descriptions for the staff of Olgreb and Maxwell's Thermic Engine, so that they cover all of the items' special powers.
3. Add descriptions for the special powers of the salamander hide armour and the macabre finger necklace.

The text from unrand.txt does cover the same sort of power, but (a) it also includes flavour text, making the item's properties less clear, and (b) it isn't included in a character dump, so that they list some of an artefact's properties, but not others.

I added some armour and jewellery as these are in a different part of the code. There are dozens of artefacts which have properties like this.

One thing which may make sense, if this was expanded, would be a way to hide bits of the standard item descriptions for some artefacts. For instance, Leech doesn't just "heals its wielder when it wounds a living foe", it heals its wielder a lot. Having a flag (say) to suppress the "vampiric" message would leave space for something more emphatic.